### PR TITLE
Enable FSDP sharding for bias

### DIFF
--- a/megablocks/layers/moe.py
+++ b/megablocks/layers/moe.py
@@ -119,7 +119,7 @@ class MoE(torch.nn.Module):
         # Note that the output bias is not parallelized with expert
         # model parallelism.
         self.bias = torch.nn.Parameter(torch.empty(
-            1, 1, args.hidden_size,
+            args.hidden_size,
             device=args.device,
             dtype=common.dtype(args)))
         torch.nn.init.zeros_(self.bias)


### PR DESCRIPTION
The bias should be automatically correctly projected to the mlp so this change should be fine. Pytorch FSDP only shards on the first dimension so this change allows the bias to also be sharded.

cc: @vchiley 