### PR TITLE
Add optional activation quantization

### DIFF
--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -32,6 +32,7 @@ class Arguments:
 
     # Compute arguments.
     memory_optimized_mlp : bool = False
+    quantize_activations_num_bits: int = -1  # -1 = no quantization
 
     # Initialization arguments.
     fp16 : bool = True

--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -6,6 +6,8 @@ from typing import Callable, Optional
 # Type annotation for in-place Tensor initialization function.
 InitFn = Callable[[torch.Tensor], None]
 
+_ALLOWED_BITWIDTHS = (-1, 4, 8)
+
 
 @dataclasses.dataclass
 class Arguments:
@@ -32,7 +34,9 @@ class Arguments:
 
     # Compute arguments.
     memory_optimized_mlp : bool = False
-    quantize_activations_num_bits: int = -1  # -1 = no quantization
+    quantize_inputs_num_bits: int = -1  # -1 = no quantization
+    quantize_rematerialize_num_bits: int = -1
+    quantize_scatter_num_bits: int = -1
 
     # Initialization arguments.
     fp16 : bool = True
@@ -43,6 +47,15 @@ class Arguments:
 
     # Benchmarking arguments.
     uniform_expert_assignment : bool = False
+
+    def __post_init__(self):
+        for attr in ('quantize_inputs_num_bits',
+                     'quantize_rematerialize_num_bits',
+                     'quantize_scatter_num_bits'):
+            nbits = self.__getattribute__(attr)
+            if nbits not in _ALLOWED_BITWIDTHS:
+                raise ValueError(f'{attr} must be one of ' +
+                                 f'{_ALLOWED_BITWIDTHS}; got {nbits}')
 
 
 def from_megatron(megatron_args):

--- a/megablocks/layers/dmoe.py
+++ b/megablocks/layers/dmoe.py
@@ -20,7 +20,6 @@ class dMoE(moe.MoE):
         self.hidden_size = args.hidden_size
         self.ffn_hidden_size = mpu.features_per_rank(args)
         self.blocking = 128
-        self.actq_num_bits = args.quantize_activations_num_bits
 
         # Sparse expert MLP.
         self.mlp = mlp.SparseMLP(args)
@@ -164,7 +163,7 @@ class dMoE(moe.MoE):
             bins,
             padded_bins,
             self.top_k,
-            self.actq_num_bits)
+            self.args.quantize_scatter_num_bits)
         return x, tokens_per_expert
 
     # For use in the base-class parallel_forward_once.

--- a/megablocks/layers/dmoe.py
+++ b/megablocks/layers/dmoe.py
@@ -20,6 +20,7 @@ class dMoE(moe.MoE):
         self.hidden_size = args.hidden_size
         self.ffn_hidden_size = mpu.features_per_rank(args)
         self.blocking = 128
+        self.actq_num_bits = args.quantize_activations_num_bits
 
         # Sparse expert MLP.
         self.mlp = mlp.SparseMLP(args)
@@ -162,7 +163,8 @@ class dMoE(moe.MoE):
             expert_weights,
             bins,
             padded_bins,
-            self.top_k)
+            self.top_k,
+            self.actq_num_bits)
         return x, tokens_per_expert
 
     # For use in the base-class parallel_forward_once.

--- a/megablocks/layers/dmoe_test.py
+++ b/megablocks/layers/dmoe_test.py
@@ -147,8 +147,8 @@ class dMoETest(parameterized.TestCase):
             self, bs, sl, hs, num_experts, top_k,
             num_input_bits=-1, num_remat_bits=-1):
         if num_input_bits > 0:
-            # quantizing input doesn't affect this test; quantizing the
-            # hidden activations *slightly* does
+            # quantizing input doesn't affect this test, so just skip configs
+            # that do this to avoid testing redundant cases
             return
         torch.manual_seed(42)
 

--- a/megablocks/layers/dmoe_test.py
+++ b/megablocks/layers/dmoe_test.py
@@ -146,8 +146,11 @@ class dMoETest(parameterized.TestCase):
     def testdMoE_ForwardVersusMoE(
             self, bs, sl, hs, num_experts, top_k,
             num_input_bits=-1, num_remat_bits=-1):
-        if num_input_bits > 0 or num_remat_bits > 0:
+        if num_input_bits > 0:
+            # quantizing input doesn't affect this test; quantizing the
+            # hidden activations *slightly* does
             return
+        torch.manual_seed(42)
 
         x = torch.randn(sl, bs, hs).half().cuda()
 
@@ -161,8 +164,7 @@ class dMoETest(parameterized.TestCase):
         out, _ = dmoe_mlp(x)
         self.assertSequenceEqual(out.shape, x.shape)
         self.assertSequenceEqual(expected_out.shape, x.shape)
-        if num_remat_bits == -1:
-            self.assertTrue(testing.allclose(out, expected_out))
+        self.assertTrue(testing.allclose(out, expected_out))
 
 
 if __name__ == '__main__':

--- a/megablocks/layers/mlp.py
+++ b/megablocks/layers/mlp.py
@@ -154,14 +154,11 @@ class MemoryOptimizedMLP(torch.autograd.Function):
 
     @staticmethod
     @torch.cuda.amp.custom_fwd
-    def forward(ctx, x, w1, w2, topo, num_bits):
+    def forward(ctx, x, w1, w2, topo, num_input_bits, num_remat_bits):
         # x: [m, k], w1: [n, k], w2: [n, k]
         if (not x.is_contiguous() or not w1.is_contiguous() or
             not w2.is_contiguous()):
             raise ValueError("Expected contiguous 'x', 'w1' and 'w2'.")
-        if num_bits not in (-1, 4, 8):
-            raise ValueError("Activation quantization num_bits must be " +
-                             f"-1 (disabled), 4, or 8. Got {num_bits}")
 
         topo_tensors = (topo.row_indices,
                         topo.column_indices,
@@ -173,24 +170,23 @@ class MemoryOptimizedMLP(torch.autograd.Function):
         # Layer 0: x @ w1.t().
         sdd_out = stk.ops.sdd(x, w1.t(), topo)
 
-        # GeLU.
-        if num_bits == -1:
-            gelu_out = gelu.gelu(sdd_out)
-            input_save_args = (x, sdd_out.data)
-        else:
-            # safe version: allocate new mem for the gelu output
-            # hidden_q, hidden_scales, gelu_out_data = turbo.quantize_signed(
-            #     sdd_out.data, num_bits=num_bits, op=turbo.ElemwiseOps.GELU_FORWARD)
-            # gelu_out = stk.Matrix(sdd_out.shape, gelu_out_data, *topo_tensors)
+        # save input tensor, quantizing if needed
+        input_save_args = (x,)
+        if num_input_bits != -1:
+            x_q, x_scales = turbo.quantize_signed(x, num_bits=num_input_bits)
+            input_save_args = (x_q, x_scales)
 
-            # bold version: lie about __restrict__ and do the GELU in-place
+        # GeLU.
+        if num_remat_bits == -1:
+            gelu_out = gelu.gelu(sdd_out)
+            input_save_args += (sdd_out.data)
+        else:
+            # fused GELU into sdd_out buffer while quantizing input
             hidden_q, hidden_scales, gelu_out_data = turbo.quantize_signed(
-                sdd_out.data, num_bits=num_bits,
+                sdd_out.data, num_bits=num_remat_bits,
                 op=turbo.ElemwiseOps.GELU_FORWARD, x_forward=sdd_out.data)
             gelu_out = sdd_out
-
-            x_q, x_scales = turbo.quantize_signed(x, num_bits=num_bits)
-            input_save_args = (x_q, x_scales, hidden_q, hidden_scales)
+            input_save_args += (hidden_q, hidden_scales)
 
         # Layer 1: x @ w2.
         dsd_out = stk.ops.dsd(gelu_out, w2)
@@ -200,12 +196,10 @@ class MemoryOptimizedMLP(torch.autograd.Function):
         # pass in the backward pass to avoid materializing another
         # intermediate.
         ctx.shape = topo.shape
-        ctx.num_bits = num_bits
+        ctx.num_input_bits = num_input_bits
+        ctx.num_remat_bits = num_remat_bits
         ctx.dtype = x.dtype
-        ctx.save_for_backward(
-            *input_save_args,
-            w1, w2, #sdd_out.data,
-            *topo_tensors)
+        ctx.save_for_backward(*input_save_args, w1, w2, *topo_tensors)
         return dsd_out
 
     @staticmethod
@@ -216,19 +210,29 @@ class MemoryOptimizedMLP(torch.autograd.Function):
             not ctx.needs_input_grad[2]):
             raise ValueError("Expected all MLP inputs to need grad.")
 
-        # rematerialize gelu output
-        num_bits = ctx.num_bits
+        # unpack saved tensors; ugly because quantizing changes tensor count
         dtype = ctx.dtype
         topo_tensors = ctx.saved_tensors[-6:]
-        if num_bits == -1:
-            x, sdd_out_data, w1, w2 = ctx.saved_tensors[:4]
+        w1, w2 = saved_tensors[-8:-6]
+        saved_tensors = ctx.saved_tensors
+        if ctx.num_input_bits == -1:
+            x = saved_tensors[0]
+            saved_tensors = saved_tensors[1:]
+        else:
+            x_q, x_scales = ctx.saved_tensors[:2]
+            saved_tensors = saved_tensors[2:]
+        if ctx.num_remat_bits == -1:
+            sdd_out_data = saved_tensors[0]
+        else:
+            hidden_q, hidden_scales = saved_tensors[:2]
+
+        # rematerialize gelu output
+        if ctx.num_remat_bits == -1:
             sdd_out = stk.Matrix(ctx.shape, sdd_out_data, *topo_tensors)
             gelu_out = gelu.gelu(sdd_out)
         else:
-            x_q, x_scales, hidden_q, hidden_scales = ctx.saved_tensors[:4]
-            w1, w2 = ctx.saved_tensors[4:6]
             gelu_out_tensor = turbo.dequantize_signed(
-                hidden_q, hidden_scales, num_bits=num_bits,
+                hidden_q, hidden_scales, num_bits=ctx.num_remat_bits,
                 op=turbo.ElemwiseOps.GELU_FORWARD, out_dtype=dtype)
             gelu_out = stk.Matrix(ctx.shape, gelu_out_tensor, *topo_tensors)
 
@@ -250,17 +254,18 @@ class MemoryOptimizedMLP(torch.autograd.Function):
         # Compute dsdd_out.
         #
         # NOTE: This reuses the dgelu_out allocation.
-        if num_bits == -1:
+        if ctx.num_remat_bits == -1:
             dsdd_out = gelu.gelu_backward_(dgelu_out, sdd_out)
         else:
             # confusingly, x_out is interpreted as the gradient to overwrite
             # in-place when the elemwise op is a backwards op
             ddsd_out_tensor = turbo.dequantize_signed(
-                hidden_q, hidden_scales, num_bits=num_bits,
+                hidden_q, hidden_scales, num_bits=ctx.num_remat_bits,
                 op=turbo.ElemwiseOps.GELU_BACKWARD, x_out=dgelu_out.data)
             dsdd_out = stk.Matrix(ctx.shape, ddsd_out_tensor, *topo_tensors)
 
-            # we also need to dequantize x
+        # rematerialize MLP input now that we need it
+        if ctx.num_input_bits != -1:
             x = turbo.dequantize_signed(
                 x_q, x_scales, num_bits=num_bits, out_dtype=dtype)
 
@@ -283,7 +288,7 @@ class MemoryOptimizedMLP(torch.autograd.Function):
             w1,
             ddsd_out)
         dx = ddsd_out
-        return dx, dw1, dw2, None, None
+        return dx, dw1, dw2, None, None, None
 
 memory_optimized_mlp = MemoryOptimizedMLP.apply
 
@@ -358,7 +363,8 @@ class SparseMLP(torch.nn.Module):
             return self.parallel_forward(x, topo)
         elif self.args.memory_optimized_mlp:
             return memory_optimized_mlp(
-                x, w1, w2, topo, self.args.quantize_activations_num_bits)
+                x, w1, w2, topo, self.args.quantize_inputs_num_bits,
+                self.args.quantize_rematerialize_num_bits)
 
         # Compute the MLP.
         x = stk.ops.sdd(x, w1.t(), topo)

--- a/megablocks/layers/mlp.py
+++ b/megablocks/layers/mlp.py
@@ -280,7 +280,7 @@ class MemoryOptimizedMLP(torch.autograd.Function):
             w1,
             ddsd_out)
         dx = ddsd_out
-        return dx, dw1, dw2, None
+        return dx, dw1, dw2, None, None
 
 memory_optimized_mlp = MemoryOptimizedMLP.apply
 

--- a/megablocks/layers/moe.py
+++ b/megablocks/layers/moe.py
@@ -410,7 +410,8 @@ class MoE(torch.nn.Module):
             expert_weights,
             bins,
             bins,
-            self.top_k)
+            self.top_k,
+            self.args.quantize_activations_num_bits)
         return x, tokens_per_expert.flatten()
 
     def forward(self, x):

--- a/megablocks/layers/moe.py
+++ b/megablocks/layers/moe.py
@@ -411,7 +411,7 @@ class MoE(torch.nn.Module):
             bins,
             bins,
             self.top_k,
-            self.args.quantize_activations_num_bits)
+            self.args.quantize_scatter_num_bits)
         return x, tokens_per_expert.flatten()
 
     def forward(self, x):

--- a/megablocks/ops/padded_scatter.py
+++ b/megablocks/ops/padded_scatter.py
@@ -49,15 +49,6 @@ class PaddedScatterOp(torch.autograd.Function):
             if ctx.num_bits == -1:  # input saved without quantization
                 x = ctx.saved_tensors[-1]
             else:  # dequantize input
-                if len(ctx.saved_tensors) != 7:
-                    # handle transient error that's probably fixed, but I can't
-                    # be sure since I could never repro it
-                    raise AssertionError(
-                        'Programming error! Forward and backward disagree ' +
-                        'on whether weights need a gradient. Saved tensor ' +
-                        f'count, shapes, dtypes: {len(ctx.saved_tensors)}, ' +
-                        f'{[t.shape for t in ctx.saved_tensors]}, ' +
-                        f'{[t.dtype for t in ctx.saved_tensors]}')
                 x_q, x_scales = ctx.saved_tensors[-2:]
                 x = turbo.dequantize_signed(
                     x_q, x_scales, num_bits=ctx.num_bits, out_shape=ctx.x_shape)

--- a/megablocks/ops/padded_scatter.py
+++ b/megablocks/ops/padded_scatter.py
@@ -49,7 +49,15 @@ class PaddedScatterOp(torch.autograd.Function):
             if ctx.num_bits == -1:
                 x = ctx.saved_tensors[0]
             else:
-                assert len(ctx.saved_tensors) == 7, f'Actual saved tensor count, shapes, dtypes: {len(ctx.saved_tensors)}, {[t.shape for t in ctx.saved_tensors]}, {[t.dtype for t in ctx.saved_tensors]}'
+                if len(ctx.saved_tensors) != 7:
+                    # handle transient error that's probably fixed, but I can't
+                    # be sure since I could never repro it
+                    raise AssertionError(
+                        'Programming error! Forward and backward disagree ' +
+                        'on whether weights need a gradient. Saved tensor ' +
+                        f'count, shapes, dtypes: {len(ctx.saved_tensors)}, ' +
+                        f'{[t.shape for t in ctx.saved_tensors]}, ' +
+                        f'{[t.dtype for t in ctx.saved_tensors]}')
                 x_q, x_scales = ctx.saved_tensors[:2]
                 x = turbo.dequantize_signed(
                     x_q, x_scales, num_bits=ctx.num_bits, out_shape=ctx.x_shape)

--- a/megablocks/ops/padded_scatter.py
+++ b/megablocks/ops/padded_scatter.py
@@ -25,6 +25,7 @@ class PaddedScatterOp(torch.autograd.Function):
     @custom_bwd
     def backward(ctx, grad):
         grad = grad.contiguous()
+        num_bits = ctx.num_bits
 
         if ctx.num_bits == -1:
             x = ctx.saved_tensors[0]

--- a/megablocks/ops/padded_scatter.py
+++ b/megablocks/ops/padded_scatter.py
@@ -10,7 +10,7 @@ class PaddedScatterOp(torch.autograd.Function):
     @custom_fwd
     def forward(ctx, x, indices, bin_ids, weights, bins, padded_bins, top_k,
                 num_bits):
-        saved_x = x if (weights is not None and ctx.needs_input_grad[3]) else None
+        saved_x = x if ctx.needs_input_grad[3] else None
         if saved_x is None:
             save_inputs = []
         elif num_bits == -1:
@@ -49,6 +49,7 @@ class PaddedScatterOp(torch.autograd.Function):
             if ctx.num_bits == -1:
                 x = ctx.saved_tensors[0]
             else:
+                assert len(ctx.saved_tensors) == 7, f'Actual saved tensor count, shapes, dtypes: {len(ctx.saved_tensors)}, {[t.shape for t in ctx.saved_tensors]}, {[t.dtype for t in ctx.saved_tensors]}'
                 x_q, x_scales = ctx.saved_tensors[:2]
                 x = turbo.dequantize_signed(
                     x_q, x_scales, num_bits=ctx.num_bits, out_shape=ctx.x_shape)

--- a/megablocks/ops/padded_scatter.py
+++ b/megablocks/ops/padded_scatter.py
@@ -10,13 +10,14 @@ class PaddedScatterOp(torch.autograd.Function):
     @custom_fwd
     def forward(ctx, x, indices, bin_ids, weights, bins, padded_bins, top_k,
                 num_bits):
-        saved_x = x if (weights is not None and weights.requires_grad) else None
+        saved_x = x if (weights is not None and ctx.needs_input_grad[3]) else None
         if saved_x is None:
             save_inputs = []
         elif num_bits == -1:
             save_inputs = (saved_x,)
         else:
-            save_inputs = turbo.quantize_signed(saved_x, num_bits=num_bits)
+            x_q, x_scales = turbo.quantize_signed(saved_x, num_bits=num_bits)
+            save_inputs = (x_q, x_scales)
 
         ctx.save_for_backward(
             *save_inputs, indices, bin_ids, weights, bins, padded_bins)

--- a/megablocks/ops/padded_scatter.py
+++ b/megablocks/ops/padded_scatter.py
@@ -56,5 +56,13 @@ class PaddedScatterOp(torch.autograd.Function):
 
 
 # wrap apply so that num_bits is optional and defaults to no quantization
-def padded_scatter(*args, num_bits: int = -1):
-    return PaddedScatterOp.apply(*args, num_bits)
+def padded_scatter(x: torch.Tensor,
+                   indices: torch.Tensor,
+                   bin_ids: torch.Tensor,
+                   weights: torch.Tensor,
+                   bins: torch.Tensor,
+                   padded_bins: torch.Tensor,
+                   top_k: int,
+                   num_bits: int = -1):
+    return PaddedScatterOp.apply(x, indices, bin_ids, weights, bins,
+                                 padded_bins, top_k, num_bits)

--- a/megablocks/ops/padded_scatter.py
+++ b/megablocks/ops/padded_scatter.py
@@ -1,17 +1,23 @@
 import torch
 from megablocks.backend import kernels
 from stk.backend.autocast import custom_fwd, custom_bwd
-
+import turbo
 
 # Autograd wrapper for padded_scatter kernel.
 class PaddedScatterOp(torch.autograd.Function):
 
     @staticmethod
     @custom_fwd
-    def forward(ctx, x, indices, bin_ids, weights, bins, padded_bins, top_k):
+    def forward(ctx, x, indices, bin_ids, weights, bins, padded_bins, top_k, num_bits):
         saved_x = None if weights is None else x
-        ctx.save_for_backward(saved_x, indices, bin_ids, weights, bins, padded_bins)
+        if num_bits == -1:
+            save_inputs = (saved_x,)
+        else:
+            save_inputs = turbo.quantize_signed(saved_x, num_bits=num_bits)
+
+        ctx.save_for_backward(*save_inputs, indices, bin_ids, weights, bins, padded_bins)
         ctx.top_k = top_k
+        ctx.num_bits = num_bits
         return kernels.padded_scatter(
             x, indices, bin_ids, weights, bins, padded_bins, top_k)
 
@@ -20,7 +26,13 @@ class PaddedScatterOp(torch.autograd.Function):
     def backward(ctx, grad):
         grad = grad.contiguous()
 
-        x, indices, bin_ids, weights, bins, padded_bins = ctx.saved_tensors
+        if ctx.num_bits == -1:
+            x = ctx.saved_tensors[0]
+        else:
+            x_q, x_scales = ctx.saved_tensors[:2]
+            x = turbo.dequantize_signed(x_q, x_scales, num_bits=num_bits)
+
+        indices, bin_ids, weights, bins, padded_bins = ctx.saved_tensors[-5:]
         out = kernels.padded_gather(
             grad,
             indices,
@@ -40,5 +52,9 @@ class PaddedScatterOp(torch.autograd.Function):
                 bins,
                 padded_bins,
                 ctx.top_k)
-        return out, None, None, wgrad, None, None, None
-padded_scatter = PaddedScatterOp.apply
+        return out, None, None, wgrad, None, None, None, None
+
+
+# wrap apply so that num_bits is optional and defaults to no quantization
+def padded_scatter(*args, num_bits: int = -1):
+    return PaddedScatterOp.apply(*args, num_bits)

--- a/megablocks/ops/padded_scatter_test.py
+++ b/megablocks/ops/padded_scatter_test.py
@@ -116,7 +116,7 @@ class PaddedScatterTest(parameterized.TestCase):
         expected_out = padded_scatter(
             x, indices, bin_ids, weights, bins, padded_bins, top_k)
 
-        out.backward(torch.randn_like(out)) # sanity check that backward pass
+        out.backward(torch.randn_like(out)) # sanity check backward pass
 
         # NOTE: We need to check approximate equality because the
         # scatter reduce uses atomics.

--- a/megablocks/ops/padded_scatter_test.py
+++ b/megablocks/ops/padded_scatter_test.py
@@ -9,9 +9,19 @@ import torch
 _PADDED_SCATTER_TESTS = (
     (4, 2, 2, 1),
     (4, 2, 2, 2),
-    (1024, 1, 4, 1),
-    (1024, 1, 4, 2),
-    (1024, 1, 4, 4),
+    (4, 2, 2, 1, 4),  # only include num_bits for some tests to avoid blowup
+    (4, 2, 2, 1, 8),
+    (4, 2, 2, 2, 4),
+    (4, 2, 2, 2, 8),
+    (1024, 1, 4, 1, -1),
+    (1024, 1, 4, 2, -1),
+    (1024, 1, 4, 4, -1),
+    (1024, 1, 4, 1, 4),
+    (1024, 1, 4, 2, 4),
+    (1024, 1, 4, 4, 4),
+    (1024, 1, 4, 1, 8),
+    (1024, 1, 4, 2, 8),
+    (1024, 1, 4, 4, 8),
     (1024, 1, 64, 1),
     (1024, 1, 64, 2),
     (1024, 1, 64, 4),
@@ -21,12 +31,16 @@ _PADDED_SCATTER_TESTS = (
     (1024, 1536, 4, 1),
     (1024, 1536, 4, 2),
     (1024, 1536, 4, 4),
+    (1024, 1536, 4, 4, 4),
+    (1024, 1536, 4, 4, 8),
     (1024, 1536, 64, 1),
     (1024, 1536, 64, 2),
     (1024, 1536, 64, 4),
     (1024, 1536, 128, 1),
     (1024, 1536, 128, 2),
     (1024, 1536, 128, 4),
+    (1024, 1536, 128, 1, 4),
+    (1024, 1536, 128, 1, 8),
     (16384, 768, 4, 1),
     (16384, 768, 4, 2),
     (16384, 768, 4, 4),
@@ -45,13 +59,15 @@ _PADDED_SCATTER_TESTS = (
     (16384, 1, 128, 1),
     (16384, 1, 128, 2),
     (16384, 1, 128, 4),
+    (16384, 1, 128, 2, 4),
+    (16384, 1, 128, 2, 8),
 )
 
 
 class PaddedScatterTest(parameterized.TestCase):
 
     @parameterized.parameters(*_PADDED_SCATTER_TESTS)
-    def testPaddedScatter(self, sl, hs, ne, top_k):
+    def testPaddedScatter(self, sl, hs, ne, top_k, num_bits=-1):
         # Create the data and indices.
         x = torch.randn((sl, hs)).cuda().half()
 
@@ -93,7 +109,7 @@ class PaddedScatterTest(parameterized.TestCase):
             return torch.from_numpy(out).cuda().half()
 
         out = ops.padded_scatter(
-            x, indices, bin_ids, weights, bins, padded_bins, top_k)
+            x, indices, bin_ids, weights, bins, padded_bins, top_k, num_bits)
         expected_out = padded_scatter(
             x, indices, bin_ids, weights, bins, padded_bins, top_k)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ torch
 numpy
 absl-py
 stanford-stk @ git+https://github.com/stanford-futuredata/stk.git@main
-mosaicml-turbo==0.0.3
+mosaicml-turbo==0.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ torch
 numpy
 absl-py
 stanford-stk @ git+https://github.com/stanford-futuredata/stk.git@main
+mosaicml-turbo==0.0.3

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ ext_modules = [
 
 install_requires=[
     'stanford-stk @ git+https://github.com/stanford-futuredata/stk.git@main',
+    'mosaicml-turbo==0.0.3',
 ]
 
 extra_deps = {}

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ ext_modules = [
 
 install_requires=[
     'stanford-stk @ git+https://github.com/stanford-futuredata/stk.git@main',
-    'mosaicml-turbo==0.0.3',
+    'mosaicml-turbo==0.0.4',
 ]
 
 extra_deps = {}


### PR DESCRIPTION
Adds activation quantization to:

* `MemoryOptimizedMLP` in `megablocks/layers/mlp.py`
* `PaddedScatterOp` in `megablocks/ops/padded_scatter.py`

To support this, we also modify:

* `megablocks/layers/arguments.py` for quantization config
* `megablocks/layers/moe.py` to pass through quantization config
* `megablocks/layers/dmoe.py` to pass through quantization config
* `megablocks/layers/dmoe_test.py` to make sure forward and backward run with quantization. Also, _we now test with `memory_optimized_mlp=True`_.
* `megablocks/ops/padded_scatter_test.py` to make sure forward and backward run with quantization.
* `requirements.txt` and `setup.py` to add the quantization library as a dependency.

[Wandb report](https://wandb.ai/mosaic-ml/davis-actq/reports/Activation-Quantization-Summary--Vmlldzo1Mzg4ODAz) with some results. tl;dr it seems to work fine as long as the GELU inputs are saved as 8b, since these influence the dgrads the most. The FFN inputs and padded_scatter inputs can be 4b. *But* we have a ton of other activations that aren't getting quantized, so we're nowhere near 2x memory savings yet.