### PR TITLE
Unpack saved context once

### DIFF
--- a/megablocks/layers/mlp.py
+++ b/megablocks/layers/mlp.py
@@ -216,18 +216,19 @@ class MemoryOptimizedMLP(torch.autograd.Function):
         # unpack saved tensors; ugly because quantizing changes tensor count
         #
         dtype = ctx.dtype
-        w1, w2 = ctx.saved_tensors[:2]
-        topo_tensors = ctx.saved_tensors[2:8]
+        saved_tensors = ctx.saved_tensors
+        w1, w2 = saved_tensors[:2]
+        topo_tensors = saved_tensors[2:8]
         # either 1 or 2 tensors for MLP input after the always-present tensors
         if ctx.num_input_bits == -1:
-            x = ctx.saved_tensors[8]
+            x = saved_tensors[8]
         else:
-            x_q, x_scales = ctx.saved_tensors[8:10]
+            x_q, x_scales = saved_tensors[8:10]
         # either 1 or 2 tensors at the end for saved GELU input / sdd output
         if ctx.num_remat_bits == -1:
-            sdd_out_data = ctx.saved_tensors[-1]
+            sdd_out_data = saved_tensors[-1]
         else:
-            hidden_q, hidden_scales = ctx.saved_tensors[-2:]
+            hidden_q, hidden_scales = saved_tensors[-2:]
 
         # rematerialize gelu output
         if ctx.num_remat_bits == -1:
@@ -434,20 +435,21 @@ class MemoryOptimizedGroupedMLP(torch.autograd.Function):
         # Unpack saved tensors; ugly because quantizing changes tensor count
         #
         dtype = ctx.dtype
-        w1, w2 = ctx.saved_tensors[:2]
-        batch_sizes = ctx.saved_tensors[2]
+        saved_tensors = ctx.saved_tensors
+        w1, w2 = saved_tensors[:2]
+        batch_sizes = saved_tensors[2]
 
         # Either 1 or 2 tensors for MLP input after the always-present tensors
         if ctx.num_input_bits == -1:
-            x = ctx.saved_tensors[3]
+            x = saved_tensors[3]
         else:
-            x_q, x_scales = ctx.saved_tensors[3:5]
+            x_q, x_scales = saved_tensors[3:5]
 
         # Either 1 or 2 tensors at the end for saved GELU input / sdd output
         if ctx.num_remat_bits == -1:
-            sdd_out = ctx.saved_tensors[-1]
+            sdd_out = saved_tensors[-1]
         else:
-            hidden_q, hidden_scales = ctx.saved_tensors[-2:]
+            hidden_q, hidden_scales = saved_tensors[-2:]
 
         # Rematerialize gelu output.
         if ctx.num_remat_bits == -1:

--- a/megablocks/ops/padded_scatter.py
+++ b/megablocks/ops/padded_scatter.py
@@ -32,8 +32,9 @@ class PaddedScatterOp(torch.autograd.Function):
     @custom_bwd
     def backward(ctx, grad):
         grad = grad.contiguous()
+        saved_tensors = ctx.saved_tensors
 
-        indices, bin_ids, weights, bins, padded_bins = ctx.saved_tensors[:5]
+        indices, bin_ids, weights, bins, padded_bins = saved_tensors[:5]
         dgrad = None
         if ctx.needs_input_grad[0]:
             dgrad = kernels.padded_gather(
@@ -48,9 +49,9 @@ class PaddedScatterOp(torch.autograd.Function):
         wgrad = None
         if ctx.needs_input_grad[3]:  # need wgrad
             if ctx.num_bits == -1:  # input saved without quantization
-                x = ctx.saved_tensors[-1]
+                x = saved_tensors[-1]
             else:  # dequantize input
-                x_q, x_scales = ctx.saved_tensors[-2:]
+                x_q, x_scales = saved_tensors[-2:]
                 x = turbo.dequantize_signed(
                     x_q, x_scales, num_bits=ctx.num_bits, out_shape=ctx.x_shape)
 

--- a/megablocks/ops/scatter.py
+++ b/megablocks/ops/scatter.py
@@ -32,8 +32,9 @@ class ScatterOp(torch.autograd.Function):
     @custom_bwd
     def backward(ctx, grad):
         grad = grad.contiguous()
+        saved_tensors = ctx.saved_tensors
 
-        indices, bin_ids, weights, bins = ctx.saved_tensors[:4]
+        indices, bin_ids, weights, bins = saved_tensors[:4]
         dgrad = None
         if ctx.needs_input_grad[0]:
             dgrad = kernels.gather(
@@ -47,9 +48,9 @@ class ScatterOp(torch.autograd.Function):
         wgrad = None
         if ctx.needs_input_grad[3]:  # need wgrad
             if ctx.num_bits == -1:  # input saved without quantization
-                x = ctx.saved_tensors[-1]
+                x = saved_tensors[-1]
             else:  # dequantize input
-                x_q, x_scales = ctx.saved_tensors[-2:]
+                x_q, x_scales = saved_tensors[-2:]
                 x = turbo.dequantize_signed(
                     x_q, x_scales, num_bits=ctx.num_bits, out_shape=ctx.x_shape)
 


### PR DESCRIPTION
Unpacks saved context once as is required for CPU offloading implementation. Ideally we unpack into named variables, but it's a little messy given what is saved depends on if we quantize or not. I just did simplest change to get it to work, but feel free to suggest refactor if appropriate