### PR TITLE
Avoid duplicate `.cpu()` call

### DIFF
--- a/megablocks/layers/moe.py
+++ b/megablocks/layers/moe.py
@@ -357,8 +357,6 @@ class ParallelMLP(torch.nn.Module):
             # Calculate the bins boundaries from the token counts.
             parallel_tokens_per_expert = parallel_tokens_per_expert.sum(
                 dim=0, dtype=torch.int)
-            parallel_tokens_per_expert_cpu = parallel_tokens_per_expert_cpu.sum(
-                dim=0, dtype=torch.int)
             parallel_bins = ops.inclusive_cumsum(
                 parallel_tokens_per_expert, 0)
             parallel_bins = (
@@ -377,7 +375,9 @@ class ParallelMLP(torch.nn.Module):
 
         # Locally permute the tokens and perform the expert computation.
         # Block to make sure that the cross-device permutation is complete.
-        parallel_tokens_per_expert = parallel_tokens_per_expert_cpu if isinstance(self.mlp, mlp.GroupedMLP) else parallel_tokens_per_expert
+        if isinstance(self.mlp, mlp.GroupedMLP):  # GroupedMLP requires counts on CPU
+            parallel_tokens_per_expert = parallel_tokens_per_expert_cpu.sum(
+                dim=0, dtype=torch.int)
         parallel_x_handle.wait()
         parallel_x = self.permute_and_compute(
             parallel_x,

--- a/megablocks/layers/moe.py
+++ b/megablocks/layers/moe.py
@@ -377,7 +377,7 @@ class ParallelMLP(torch.nn.Module):
 
         # Locally permute the tokens and perform the expert computation.
         # Block to make sure that the cross-device permutation is complete.
-        print(f'Recv counts: {recv_counts}')
+        print(f'Tokens per expert: {parallel_tokens_per_expert}')
         print(f'Tokens per expert CPU: {parallel_tokens_per_expert_cpu}')
         parallel_x_handle.wait()
         parallel_x = self.permute_and_compute(

--- a/megablocks/layers/moe.py
+++ b/megablocks/layers/moe.py
@@ -377,7 +377,7 @@ class ParallelMLP(torch.nn.Module):
         # Block to make sure that the cross-device permutation is complete.
         if isinstance(self.mlp, mlp.GroupedMLP):
             # GroupedMLP requires counts on CPU. We can use the tensor already
-            # moved to CPU in the prior all_to_all, which avoids an extra
+            # moved to CPU for the prior all_to_all, which avoids an extra
             # device synchronization.
             parallel_tokens_per_expert = parallel_tokens_per_expert_cpu.sum(
                 dim=0, dtype=torch.int)

--- a/megablocks/layers/moe.py
+++ b/megablocks/layers/moe.py
@@ -377,8 +377,7 @@ class ParallelMLP(torch.nn.Module):
 
         # Locally permute the tokens and perform the expert computation.
         # Block to make sure that the cross-device permutation is complete.
-        print(f'Tokens per expert: {parallel_tokens_per_expert}')
-        print(f'Tokens per expert CPU: {parallel_tokens_per_expert_cpu}')
+        parallel_tokens_per_expert = parallel_tokens_per_expert_cpu if isinstance(self.mlp, mlp.GroupedMLP) else parallel_tokens_per_expert
         parallel_x_handle.wait()
         parallel_x = self.permute_and_compute(
             parallel_x,

--- a/megablocks/layers/moe.py
+++ b/megablocks/layers/moe.py
@@ -374,6 +374,8 @@ class ParallelMLP(torch.nn.Module):
 
         # Locally permute the tokens and perform the expert computation.
         # Block to make sure that the cross-device permutation is complete.
+        print(f'Recv counts: {recv_counts}')
+        print(f'Tokens per expert: {parallel_tokens_per_expert}')
         parallel_x_handle.wait()
         parallel_x = self.permute_and_compute(
             parallel_x,

--- a/megablocks/layers/moe.py
+++ b/megablocks/layers/moe.py
@@ -375,9 +375,9 @@ class ParallelMLP(torch.nn.Module):
 
         # Locally permute the tokens and perform the expert computation.
         # Block to make sure that the cross-device permutation is complete.
-        if isinstance(self.mlp, mlp.GroupedMLP):  # GroupedMLP requires counts on CPU
+        if isinstance(self.mlp, mlp.GroupedMLP):
             parallel_tokens_per_expert = parallel_tokens_per_expert_cpu.sum(
-                dim=0, dtype=torch.int)
+                dim=0, dtype=torch.int)  # GroupedMLP requires counts on CPU
         parallel_x_handle.wait()
         parallel_x = self.permute_and_compute(
             parallel_x,

--- a/megablocks/layers/moe.py
+++ b/megablocks/layers/moe.py
@@ -299,6 +299,7 @@ class ParallelMLP(torch.nn.Module):
             # TODO(tgale): It might be faster to do this on the GPU and
             # then communicate the results back to the host.
             send_counts = repeated_tokens_per_expert.cpu().sum(dim=-1)
+            print(f'Parallel tokens per expert: {parallel_tokens_per_expert}')
             recv_counts = parallel_tokens_per_expert.cpu().sum(dim=-1)
 
             # Convert the send/recv counts to lists.


### PR DESCRIPTION
Avoid duplicate `.cpu()` call by using cached CPU counts