### PR TITLE
Add GLU support

### DIFF
--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -39,7 +39,7 @@ class Arguments:
     # Compute arguments.
     memory_optimized_mlp : bool = False
     mlp_type: str = 'mlp'
-    use_grouped_gemm: bool = False
+    grouped_mlp: bool = False
     quantize_inputs_num_bits: int = -1  # -1 = no quantization
     quantize_rematerialize_num_bits: int = -1
     quantize_scatter_num_bits: int = -1
@@ -66,7 +66,7 @@ class Arguments:
             if nbits != -1:
                 turbo.assert_turbo_is_available()
 
-        if self.__getattribute__('use_grouped_gemm'):
+        if self.__getattribute__('grouped_mlp'):
             grouped_gemm.assert_grouped_gemm_is_available()
 
 

--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -38,7 +38,7 @@ class Arguments:
 
     # Compute arguments.
     memory_optimized_mlp : bool = False
-    grouped_mlp : bool = False
+    mlp_type: str = 'sparse_mlp'
     quantize_inputs_num_bits: int = -1  # -1 = no quantization
     quantize_rematerialize_num_bits: int = -1
     quantize_scatter_num_bits: int = -1
@@ -65,7 +65,7 @@ class Arguments:
             if nbits != -1:
                 turbo.assert_turbo_is_available()
 
-        if self.__getattribute__('grouped_mlp'):
+        if self.__getattribute__('mlp_type') == 'grouped_mlp':
             grouped_gemm.assert_grouped_gemm_is_available()
 
 

--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -66,7 +66,7 @@ class Arguments:
             if nbits != -1:
                 turbo.assert_turbo_is_available()
 
-        if self.__getattribute__('mlp_type') == 'grouped_mlp':
+        if self.__getattribute__('use_grouped_gemm'):
             grouped_gemm.assert_grouped_gemm_is_available()
 
 

--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -38,7 +38,8 @@ class Arguments:
 
     # Compute arguments.
     memory_optimized_mlp : bool = False
-    mlp_type: str = 'sparse_mlp'
+    mlp_type: str = 'mlp'
+    use_grouped_gemm: bool = False
     quantize_inputs_num_bits: int = -1  # -1 = no quantization
     quantize_rematerialize_num_bits: int = -1
     quantize_scatter_num_bits: int = -1

--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -38,8 +38,8 @@ class Arguments:
 
     # Compute arguments.
     memory_optimized_mlp : bool = False
-    mlp_type: str = 'mlp'
-    grouped_mlp: bool = False
+    mlp_type : str = 'mlp'
+    grouped_mlp : bool = False
     quantize_inputs_num_bits: int = -1  # -1 = no quantization
     quantize_rematerialize_num_bits: int = -1
     quantize_scatter_num_bits: int = -1

--- a/megablocks/layers/dmlp_registry.py
+++ b/megablocks/layers/dmlp_registry.py
@@ -5,9 +5,10 @@ from megablocks.layers.arguments import Arguments
 
 MlpType = Union[mlp.SparseMLP, glu.SparseGLU]
 
-class MlpRegistry:
+class DMlpRegistry:
     """
     Abstraction for creating different underlying MLPs.
+    Currently only supports MLPs that are used by dMoE. 
     """
     REGISTRY = {
         'mlp': {'grouped': mlp.GroupedMLP, 'sparse' : mlp.SparseMLP},
@@ -17,12 +18,12 @@ class MlpRegistry:
     @staticmethod
     def get(args: Arguments) -> MlpType:
 
-        if args.mlp_type not in MlpRegistry.REGISTRY: 
+        if args.mlp_type not in DMlpRegistry.REGISTRY: 
             raise ValueError(f'Unsupported mlp type: {args.mlp_type}')
 
         mlp_impl = 'grouped' if args.use_grouped_gemm else 'sparse'
 
-        if mlp_impl not in MlpRegistry.REGISTRY[args.mlp_type]:
+        if mlp_impl not in DMlpRegistry.REGISTRY[args.mlp_type]:
             raise ValueError(f'{args.mlp_type} does not support {mlp_impl} backend.')
 
-        return MlpRegistry.REGISTRY[args.mlp_type][mlp_impl](args)
+        return DMlpRegistry.REGISTRY[args.mlp_type][mlp_impl](args)

--- a/megablocks/layers/dmlp_registry.py
+++ b/megablocks/layers/dmlp_registry.py
@@ -5,7 +5,7 @@ from megablocks.layers.arguments import Arguments
 
 MlpType = Union[mlp.SparseMLP, glu.SparseGLU]
 
-class DMlpRegistry:
+class dMlpRegistry:
     """
     Abstraction for creating different underlying MLPs.
     Currently only supports MLPs that are used by dMoE. 
@@ -18,12 +18,12 @@ class DMlpRegistry:
     @staticmethod
     def get(args: Arguments) -> MlpType:
 
-        if args.mlp_type not in DMlpRegistry.REGISTRY: 
+        if args.mlp_type not in dMlpRegistry.REGISTRY: 
             raise ValueError(f'Unsupported mlp type: {args.mlp_type}')
 
-        mlp_impl = 'grouped' if args.use_grouped_gemm else 'sparse'
+        mlp_impl = 'grouped' if args.grouped_mlp else 'sparse'
 
-        if mlp_impl not in DMlpRegistry.REGISTRY[args.mlp_type]:
+        if mlp_impl not in dMlpRegistry.REGISTRY[args.mlp_type]:
             raise ValueError(f'{args.mlp_type} does not support {mlp_impl} backend.')
 
-        return DMlpRegistry.REGISTRY[args.mlp_type][mlp_impl](args)
+        return dMlpRegistry.REGISTRY[args.mlp_type][mlp_impl](args)

--- a/megablocks/layers/dmoe.py
+++ b/megablocks/layers/dmoe.py
@@ -27,10 +27,8 @@ class ParallelDroplessMLP(moe.ParallelMLP):
         self.ffn_hidden_size = mpu.features_per_rank(args)
         self.blocking = 128
 
-        self.use_grouped_gemm = args.use_grouped_gemm
-
         if args.mlp_type in MLP_TYPE_REGISTRY: 
-            mlp_impl = 'grouped' if self.use_grouped_gemm else 'sparse'
+            mlp_impl = 'grouped' if self.args.use_grouped_gemm else 'sparse'
             if mlp_impl in MLP_TYPE_REGISTRY[args.mlp_type]:
                 self.mlp = MLP_TYPE_REGISTRY[args.mlp_type][mlp_impl](args)
             else:
@@ -283,7 +281,7 @@ class ParallelDroplessMLP(moe.ParallelMLP):
             self.args.quantize_scatter_num_bits)
 
     def forward_once(self, x, expert_weights, top_experts):
-        if self.use_grouped_gemm:
+        if self.args.use_grouped_gemm:
             return self.grouped_forward_once(
                 x, expert_weights, top_experts)
         return self.sparse_forward_once(
@@ -299,7 +297,7 @@ class ParallelDroplessMLP(moe.ParallelMLP):
             bins,
             expert_capactiy,
             top_k):
-        if self.use_grouped_gemm:
+        if self.args.use_grouped_gemm:
             return self.grouped_permute_and_compute(
                 x,
                 tokens_per_expert,

--- a/megablocks/layers/dmoe.py
+++ b/megablocks/layers/dmoe.py
@@ -1,6 +1,6 @@
 from megablocks.layers import common
 from megablocks.layers import moe
-from megablocks.layers.dmlp_registry import DMlpRegistry
+from megablocks.layers.dmlp_registry import dMlpRegistry
 from megablocks.layers import mpu
 from megablocks.layers import router
 from megablocks.layers.arguments import Arguments
@@ -19,7 +19,7 @@ class ParallelDroplessMLP(moe.ParallelMLP):
         self.hidden_size = args.hidden_size
         self.ffn_hidden_size = mpu.features_per_rank(args)
         self.blocking = 128
-        self.mlp = DMlpRegistry.get(args)
+        self.mlp = dMlpRegistry.get(args)
 
         # Calculate the number of bits needed to represent the column indices
         # in the intermediate sparse matrix.
@@ -265,7 +265,7 @@ class ParallelDroplessMLP(moe.ParallelMLP):
             self.args.quantize_scatter_num_bits)
 
     def forward_once(self, x, expert_weights, top_experts):
-        if self.args.use_grouped_gemm:
+        if self.args.grouped_mlp:
             return self.grouped_forward_once(
                 x, expert_weights, top_experts)
         return self.sparse_forward_once(
@@ -281,7 +281,7 @@ class ParallelDroplessMLP(moe.ParallelMLP):
             bins,
             expert_capactiy,
             top_k):
-        if self.args.use_grouped_gemm:
+        if self.args.grouped_mlp:
             return self.grouped_permute_and_compute(
                 x,
                 tokens_per_expert,

--- a/megablocks/layers/dmoe.py
+++ b/megablocks/layers/dmoe.py
@@ -15,8 +15,8 @@ def promote_scalar(x):
     return x.view(1) if not len(x.size()) else x
 
 MLP_TYPE_REGISTRY = {
-    'mlp': {'grouped': mlp.GroupedMLP, 'triton' : mlp.MLP},
-    'glu': {'grouped': glu.GroupedGLU, 'triton': glu.GLU},
+    'mlp': {'grouped': mlp.GroupedMLP, 'sparse' : mlp.SparseMLP},
+    'glu': {'grouped': glu.GroupedGLU, 'sparse': glu.SparseGLU},
 }
 
 class ParallelDroplessMLP(moe.ParallelMLP):
@@ -30,7 +30,7 @@ class ParallelDroplessMLP(moe.ParallelMLP):
         self.use_grouped_gemm = args.use_grouped_gemm
 
         if args.mlp_type in MLP_TYPE_REGISTRY: 
-            mlp_impl = 'grouped' if self.use_grouped_gemm else 'triton'
+            mlp_impl = 'grouped' if self.use_grouped_gemm else 'sparse'
             if mlp_impl in MLP_TYPE_REGISTRY[args.mlp_type]:
                 self.mlp = MLP_TYPE_REGISTRY[args.mlp_type][mlp_impl](args)
             else:

--- a/megablocks/layers/dmoe.py
+++ b/megablocks/layers/dmoe.py
@@ -1,6 +1,6 @@
 from megablocks.layers import common
 from megablocks.layers import moe
-from megablocks.layers.dmlp_registry import dMlpRegistry
+from megablocks.layers import dmlp_registry
 from megablocks.layers import mpu
 from megablocks.layers import router
 from megablocks.layers.arguments import Arguments
@@ -19,7 +19,7 @@ class ParallelDroplessMLP(moe.ParallelMLP):
         self.hidden_size = args.hidden_size
         self.ffn_hidden_size = mpu.features_per_rank(args)
         self.blocking = 128
-        self.mlp = dMlpRegistry.get(args)
+        self.mlp = dmlp_registry.get(args)
 
         # Calculate the number of bits needed to represent the column indices
         # in the intermediate sparse matrix.

--- a/megablocks/layers/dmoe.py
+++ b/megablocks/layers/dmoe.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from megablocks.layers import common
 from megablocks.layers import mlp
 from megablocks.layers import glu

--- a/megablocks/layers/dmoe.py
+++ b/megablocks/layers/dmoe.py
@@ -1,6 +1,6 @@
 from megablocks.layers import common
 from megablocks.layers import moe
-from megablocks.layers.mlp_registry import MlpRegistry
+from megablocks.layers.dmlp_registry import DMlpRegistry
 from megablocks.layers import mpu
 from megablocks.layers import router
 from megablocks.layers.arguments import Arguments
@@ -19,7 +19,7 @@ class ParallelDroplessMLP(moe.ParallelMLP):
         self.hidden_size = args.hidden_size
         self.ffn_hidden_size = mpu.features_per_rank(args)
         self.blocking = 128
-        self.mlp = MlpRegistry.get(args)
+        self.mlp = DMlpRegistry.get(args)
 
         # Calculate the number of bits needed to represent the column indices
         # in the intermediate sparse matrix.

--- a/megablocks/layers/dmoe_test.py
+++ b/megablocks/layers/dmoe_test.py
@@ -18,7 +18,7 @@ def test_modules(
         moe_top_k=1,
         num_input_bits=-1,
         num_remat_bits=-1,
-        use_grouped_gemm=False):
+        grouped_mlp=False):
     init_method = partial(torch.nn.init.normal_, mean=0.0, std=0.1)
     args = Arguments(
         hidden_size=hidden_size,
@@ -31,7 +31,7 @@ def test_modules(
         quantize_inputs_num_bits=num_input_bits,
         quantize_rematerialize_num_bits=num_remat_bits,
         mlp_type='mlp',
-        use_grouped_gemm=use_grouped_gemm,
+        grouped_mlp=grouped_mlp,
         fp16=False,
         bf16=True)
 
@@ -122,7 +122,7 @@ class dMoETest(parameterized.TestCase):
     @parameterized.parameters(*_FORWARD_TESTS)
     def testdMoE_Forward(self, bs, sl, hs, num_experts, top_k,
                          num_input_bits=-1, num_remat_bits=-1,
-                         use_grouped_gemm=False):
+                         grouped_mlp=False):
         x = torch.randn(sl, bs, hs).to(torch.bfloat16).cuda()
 
         _, _, _, layer = test_modules(
@@ -132,7 +132,7 @@ class dMoETest(parameterized.TestCase):
             moe_top_k=top_k,
             num_input_bits=num_input_bits,
             num_remat_bits=num_remat_bits,
-            use_grouped_gemm=use_grouped_gemm)
+            grouped_mlp=grouped_mlp)
 
         out, _ = layer(x)
         self.assertSequenceEqual(out.shape, x.shape)
@@ -141,7 +141,7 @@ class dMoETest(parameterized.TestCase):
     def testdMoE_ForwardBackward(
             self, bs, sl, hs, num_experts, top_k,
             num_input_bits=-1, num_remat_bits=-1,
-            use_grouped_gemm=False):
+            grouped_mlp=False):
         x = torch.randn(sl, bs, hs).to(torch.bfloat16).cuda()
         x.requires_grad_(True)
 
@@ -152,7 +152,7 @@ class dMoETest(parameterized.TestCase):
             moe_top_k=top_k,
             num_input_bits=num_input_bits,
             num_remat_bits=num_remat_bits,
-            use_grouped_gemm=use_grouped_gemm)
+            grouped_mlp=grouped_mlp)
 
         out, _ = layer(x)
         self.assertSequenceEqual(out.shape, x.shape)
@@ -183,7 +183,7 @@ class dMoETest(parameterized.TestCase):
     def testdMoE_ForwardVersusMoE(
             self, bs, sl, hs, num_experts, top_k,
             num_input_bits=-1, num_remat_bits=-1,
-            use_grouped_gemm=False):
+            grouped_mlp=False):
         torch.manual_seed(42)
 
         x = torch.randn(sl, bs, hs).to(torch.bfloat16).cuda()
@@ -193,7 +193,7 @@ class dMoETest(parameterized.TestCase):
             ffn_hidden_size=hs,
             moe_num_experts=num_experts,
             moe_capacity_factor=0,
-            use_grouped_gemm=use_grouped_gemm)
+            grouped_mlp=grouped_mlp)
 
         expected_out, _= moe_mlp(x)
         out, _ = dmoe_mlp(x)

--- a/megablocks/layers/dmoe_test.py
+++ b/megablocks/layers/dmoe_test.py
@@ -18,7 +18,6 @@ def test_modules(
         moe_top_k=1,
         num_input_bits=-1,
         num_remat_bits=-1,
-        mlp_type='mlp',
         use_grouped_gemm=False):
     init_method = partial(torch.nn.init.normal_, mean=0.0, std=0.1)
     args = Arguments(
@@ -31,7 +30,7 @@ def test_modules(
         memory_optimized_mlp=True,
         quantize_inputs_num_bits=num_input_bits,
         quantize_rematerialize_num_bits=num_remat_bits,
-        mlp_type=mlp_type,
+        mlp_type='mlp',
         use_grouped_gemm=use_grouped_gemm,
         fp16=False,
         bf16=True)
@@ -74,7 +73,7 @@ _FORWARD_TESTS_NO_QUANTIZE = (
 )
 
 _FORWARD_TESTS_GROUPED_MLP = tuple([
-    p + (-1, -1, 'mlp', True) for p in _FORWARD_TESTS_NO_QUANTIZE
+    p + (-1, -1, True) for p in _FORWARD_TESTS_NO_QUANTIZE
 ])
 
 # quantization tests; assorted small sizes, systematic bitwidths
@@ -123,7 +122,7 @@ class dMoETest(parameterized.TestCase):
     @parameterized.parameters(*_FORWARD_TESTS)
     def testdMoE_Forward(self, bs, sl, hs, num_experts, top_k,
                          num_input_bits=-1, num_remat_bits=-1,
-                         mlp_type='mlp', use_grouped_gemm=False):
+                         use_grouped_gemm=False):
         x = torch.randn(sl, bs, hs).to(torch.bfloat16).cuda()
 
         _, _, _, layer = test_modules(
@@ -133,7 +132,6 @@ class dMoETest(parameterized.TestCase):
             moe_top_k=top_k,
             num_input_bits=num_input_bits,
             num_remat_bits=num_remat_bits,
-             mlp_type=mlp_type,
             use_grouped_gemm=use_grouped_gemm)
 
         out, _ = layer(x)
@@ -143,7 +141,7 @@ class dMoETest(parameterized.TestCase):
     def testdMoE_ForwardBackward(
             self, bs, sl, hs, num_experts, top_k,
             num_input_bits=-1, num_remat_bits=-1,
-            mlp_type='mlp', use_grouped_gemm=False):
+            use_grouped_gemm=False):
         x = torch.randn(sl, bs, hs).to(torch.bfloat16).cuda()
         x.requires_grad_(True)
 
@@ -154,7 +152,6 @@ class dMoETest(parameterized.TestCase):
             moe_top_k=top_k,
             num_input_bits=num_input_bits,
             num_remat_bits=num_remat_bits,
-            mlp_type=mlp_type,
             use_grouped_gemm=use_grouped_gemm)
 
         out, _ = layer(x)
@@ -186,7 +183,7 @@ class dMoETest(parameterized.TestCase):
     def testdMoE_ForwardVersusMoE(
             self, bs, sl, hs, num_experts, top_k,
             num_input_bits=-1, num_remat_bits=-1,
-            mlp_type='mlp', use_grouped_gemm=False):
+            use_grouped_gemm=False):
         torch.manual_seed(42)
 
         x = torch.randn(sl, bs, hs).to(torch.bfloat16).cuda()
@@ -196,7 +193,6 @@ class dMoETest(parameterized.TestCase):
             ffn_hidden_size=hs,
             moe_num_experts=num_experts,
             moe_capacity_factor=0,
-             mlp_type=mlp_type,
             use_grouped_gemm=use_grouped_gemm)
 
         expected_out, _= moe_mlp(x)

--- a/megablocks/layers/glu.py
+++ b/megablocks/layers/glu.py
@@ -9,7 +9,7 @@ import torch
 import torch.nn.functional as F
 
 
-class GLU(SparseMLP):
+class SparseGLU(SparseMLP):
 
     def __init__(self, args : Arguments):
         super().__init__(args)
@@ -49,7 +49,7 @@ class GLU(SparseMLP):
 
         return stk.ops.dsd(x1, w2)
     
-class GroupedGLU(GLU):
+class GroupedGLU(SparseGLU):
     def forward(self, x, tokens_per_expert):
         batch_sizes = tokens_per_expert.cpu().to(torch.long)
         w1, v1, w2 = (self.scale_grad(self.w1), self.scale_grad(self.v1), self.scale_grad(self.w2))

--- a/megablocks/layers/glu.py
+++ b/megablocks/layers/glu.py
@@ -1,80 +1,37 @@
 from megablocks.layers import common
 from megablocks.layers import gelu
-from megablocks.layers.mlp import create_dmoe_expert_weights, scale_gradient
+from megablocks.layers.mlp import SparseMLP, create_dmoe_expert_weights
 from megablocks.layers import mpu
-from megablocks.layers import weight_parallel as wp
 from megablocks.layers.arguments import Arguments, InitFn
-from megablocks import turbo_util as turbo
-from megablocks import grouped_gemm_util as gg
 import stk
 import torch
 import torch.nn.functional as F
 
 
-class GLU(torch.nn.Module):
+class GLU(SparseMLP):
 
     def __init__(self, args : Arguments):
-        super().__init__()
-        self.args = args
+        super().__init__(args)
         num_rows_per_rank = (
             (mpu.experts_per_rank(args) * mpu.features_per_rank(args)) //
             mpu.get_weight_parallel_world_size(args)
         )
-
-        self.w1 = torch.nn.Parameter(torch.empty(
-            num_rows_per_rank,
-            args.hidden_size,
-            device=args.device,
-            dtype=common.dtype(args)))
 
         self.v1 = torch.nn.Parameter(torch.empty(
             num_rows_per_rank,
             args.hidden_size,
             device=args.device,
             dtype=common.dtype(args)))
-
-        self.w2 = torch.nn.Parameter(torch.empty(
-            num_rows_per_rank,
-            args.hidden_size,
-            device=args.device,
-            dtype=common.dtype(args)))
-
-        # Initialize the parameters for the MLP.
-        #
-        # NOTE: It is important that we create the weight tensors prior
-        # to creating the master weights and slicing our the piece for
-        # this rank. If the master weights are created first the PyTorch
-        # caching allocator appears to use the same memory block for these
-        # and the slice which causes large increases in our peak memory
-        # usage.
         with torch.no_grad():
-            self.w1.copy_(create_dmoe_expert_weights(
-                args, args.moe_num_experts, args.ffn_hidden_size,
-                args.hidden_size, args.init_method))
             self.v1.copy_(create_dmoe_expert_weights(
                 args, args.moe_num_experts, args.ffn_hidden_size,
                 args.hidden_size, args.init_method))
-            self.w2.copy_(create_dmoe_expert_weights(
-                args, args.moe_num_experts, args.ffn_hidden_size,
-                args.hidden_size, args.output_layer_init_method))
 
         should_set_attribute = (
             args.moe_expert_model_parallelism or args.moe_weight_parallelism)
-        mpu.set_expert_model_parallel_attributes(
-            self.w1, should_set_attribute)
+
         mpu.set_expert_model_parallel_attributes(
             self.v1, should_set_attribute)
-        mpu.set_expert_model_parallel_attributes(
-            self.w2, should_set_attribute)
-
-        self.gradient_scale = None
-        if self.args.moe_expert_model_parallelism:
-            self.gradient_scale = 1 / mpu.get_expert_parallel_world_size(self.args)
-
-    def scale_grad(self, w):
-        if self.gradient_scale is None:
-            return w
-        return scale_gradient(w, self.gradient_scale)
 
     def forward(self, x, topo):
         w1, v1, w2 = (self.scale_grad(self.w1), self.scale_grad(self.v1), self.scale_grad(self.w2))
@@ -83,11 +40,10 @@ class GLU(torch.nn.Module):
         elif self.args.memory_optimized_mlp:
             raise NotImplementedError("Currently not supported.")
 
-        # Compute the MLP.
+        # Compute the GLU.
         x1 = stk.ops.sdd(x, w1.t(), topo)
         x2 = stk.ops.sdd(x, v1.t(), topo)
 
-        element_wise_res = stk.ops.to_dense(gelu.gelu(x1)) * stk.ops.to_dense(x2)
-        sparse_res = stk.ops.to_sparse(element_wise_res, 128)
+        x1._data = gelu.gelu(x1)._data * x2._data
 
-        return stk.ops.dsd(sparse_res, w2)
+        return stk.ops.dsd(x1, w2)

--- a/megablocks/layers/glu.py
+++ b/megablocks/layers/glu.py
@@ -38,7 +38,7 @@ class SparseGLU(SparseMLP):
         x1 = stk.ops.sdd(x, w1.t(), topo)
         x2 = stk.ops.sdd(x, v1.t(), topo)
 
-        x1._data = gelu.gelu(x1)._data * x2._data
+        x1 = stk.ops.mul(gelu.gelu(x1), x2)
 
         return stk.ops.dsd(x1, w2)
 

--- a/megablocks/layers/glu.py
+++ b/megablocks/layers/glu.py
@@ -25,7 +25,7 @@ class SparseGLU(SparseMLP):
 
         mpu.set_expert_model_parallel_attributes(
             self.v1, self._should_set_parallelism_attribute)
-        
+
         if self.args.moe_weight_parallelism:
             raise NotImplementedError("Weight parallelism not yet supported with GLU.")
         elif self.args.memory_optimized_mlp:
@@ -41,7 +41,7 @@ class SparseGLU(SparseMLP):
         x1._data = gelu.gelu(x1)._data * x2._data
 
         return stk.ops.dsd(x1, w2)
-    
+
 class GroupedGLU(SparseGLU):
     def forward(self, x, tokens_per_expert):
         batch_sizes = tokens_per_expert.cpu().to(torch.long)

--- a/megablocks/layers/glu.py
+++ b/megablocks/layers/glu.py
@@ -1,0 +1,93 @@
+from megablocks.layers import common
+from megablocks.layers import gelu
+from megablocks.layers.mlp import create_dmoe_expert_weights, scale_gradient
+from megablocks.layers import mpu
+from megablocks.layers import weight_parallel as wp
+from megablocks.layers.arguments import Arguments, InitFn
+from megablocks import turbo_util as turbo
+from megablocks import grouped_gemm_util as gg
+import stk
+import torch
+import torch.nn.functional as F
+
+
+class GLU(torch.nn.Module):
+
+    def __init__(self, args : Arguments):
+        super().__init__()
+        self.args = args
+        num_rows_per_rank = (
+            (mpu.experts_per_rank(args) * mpu.features_per_rank(args)) //
+            mpu.get_weight_parallel_world_size(args)
+        )
+
+        self.w1 = torch.nn.Parameter(torch.empty(
+            num_rows_per_rank,
+            args.hidden_size,
+            device=args.device,
+            dtype=common.dtype(args)))
+
+        self.v1 = torch.nn.Parameter(torch.empty(
+            num_rows_per_rank,
+            args.hidden_size,
+            device=args.device,
+            dtype=common.dtype(args)))
+
+        self.w2 = torch.nn.Parameter(torch.empty(
+            num_rows_per_rank,
+            args.hidden_size,
+            device=args.device,
+            dtype=common.dtype(args)))
+
+        # Initialize the parameters for the MLP.
+        #
+        # NOTE: It is important that we create the weight tensors prior
+        # to creating the master weights and slicing our the piece for
+        # this rank. If the master weights are created first the PyTorch
+        # caching allocator appears to use the same memory block for these
+        # and the slice which causes large increases in our peak memory
+        # usage.
+        with torch.no_grad():
+            self.w1.copy_(create_dmoe_expert_weights(
+                args, args.moe_num_experts, args.ffn_hidden_size,
+                args.hidden_size, args.init_method))
+            self.v1.copy_(create_dmoe_expert_weights(
+                args, args.moe_num_experts, args.ffn_hidden_size,
+                args.hidden_size, args.init_method))
+            self.w2.copy_(create_dmoe_expert_weights(
+                args, args.moe_num_experts, args.ffn_hidden_size,
+                args.hidden_size, args.output_layer_init_method))
+
+        should_set_attribute = (
+            args.moe_expert_model_parallelism or args.moe_weight_parallelism)
+        mpu.set_expert_model_parallel_attributes(
+            self.w1, should_set_attribute)
+        mpu.set_expert_model_parallel_attributes(
+            self.v1, should_set_attribute)
+        mpu.set_expert_model_parallel_attributes(
+            self.w2, should_set_attribute)
+
+        self.gradient_scale = None
+        if self.args.moe_expert_model_parallelism:
+            self.gradient_scale = 1 / mpu.get_expert_parallel_world_size(self.args)
+
+    def scale_grad(self, w):
+        if self.gradient_scale is None:
+            return w
+        return scale_gradient(w, self.gradient_scale)
+
+    def forward(self, x, topo):
+        w1, v1, w2 = (self.scale_grad(self.w1), self.scale_grad(self.v1), self.scale_grad(self.w2))
+        if self.args.moe_weight_parallelism:
+            raise NotImplementedError("Currently not supported.")
+        elif self.args.memory_optimized_mlp:
+            raise NotImplementedError("Currently not supported.")
+
+        # Compute the MLP.
+        x1 = stk.ops.sdd(x, w1.t(), topo)
+        x2 = stk.ops.sdd(x, v1.t(), topo)
+
+        element_wise_res = stk.ops.to_dense(gelu.gelu(x1)) * stk.ops.to_dense(x2)
+        sparse_res = stk.ops.to_sparse(element_wise_res, 128)
+
+        return stk.ops.dsd(sparse_res, w2)

--- a/megablocks/layers/glu.py
+++ b/megablocks/layers/glu.py
@@ -3,6 +3,7 @@ from megablocks.layers import gelu
 from megablocks.layers.mlp import SparseMLP, create_dmoe_expert_weights
 from megablocks.layers import mpu
 from megablocks.layers.arguments import Arguments, InitFn
+from megablocks import grouped_gemm_util as gg
 import stk
 import torch
 import torch.nn.functional as F
@@ -36,9 +37,9 @@ class GLU(SparseMLP):
     def forward(self, x, topo):
         w1, v1, w2 = (self.scale_grad(self.w1), self.scale_grad(self.v1), self.scale_grad(self.w2))
         if self.args.moe_weight_parallelism:
-            raise NotImplementedError("Currently not supported.")
+            raise NotImplementedError("Weight parallelism not yet supported with GLU.")
         elif self.args.memory_optimized_mlp:
-            raise NotImplementedError("Currently not supported.")
+            raise NotImplementedError("Memory optimized implementation not yet supported with GLU.")
 
         # Compute the GLU.
         x1 = stk.ops.sdd(x, w1.t(), topo)
@@ -47,3 +48,28 @@ class GLU(SparseMLP):
         x1._data = gelu.gelu(x1)._data * x2._data
 
         return stk.ops.dsd(x1, w2)
+    
+class GroupedGLU(GLU):
+    def forward(self, x, tokens_per_expert):
+        batch_sizes = tokens_per_expert.cpu().to(torch.long)
+        w1, v1, w2 = (self.scale_grad(self.w1), self.scale_grad(self.v1), self.scale_grad(self.w2))
+
+        # Re-shape the weights for the grouped GEMMs.
+        ne = mpu.experts_per_rank(self.args)
+        w1 = w1.view(ne, -1, self.args.hidden_size)
+        v1 = v1.view(ne, -1, self.args.hidden_size)
+        w2 = w2.view(ne, -1, self.args.hidden_size)
+
+        if self.args.moe_weight_parallelism:
+            raise ValueError(
+                "Weight parallelism not yet supported with GroupedMLP.")
+
+        if self.args.memory_optimized_mlp:
+            raise ValueError(
+                "Memory optimized implementation not yet supported with GroupedGLU.")
+
+        # Compute the MLP.
+        x1 = gg.ops.gmm(x, w1, batch_sizes, trans_b=True)
+        x2 = gg.ops.gmm(x, v1, batch_sizes, trans_b=True)
+        x1 = F.gelu(x1, approximate="tanh") * x2
+        return gg.ops.gmm(x1, w2, batch_sizes)

--- a/megablocks/layers/glu_test.py
+++ b/megablocks/layers/glu_test.py
@@ -49,7 +49,6 @@ class GLUTest(parameterized.TestCase):
 
     @parameterized.parameters(*_DENSE_TESTS)
     def testGLU_ForwardGroupedMLP(self, bs, sl, hs):
-
         x = torch.randn(sl, bs, hs).to(torch.bfloat16).cuda()
 
         _, glu, dmoe_glu = test_modules(

--- a/megablocks/layers/glu_test.py
+++ b/megablocks/layers/glu_test.py
@@ -48,7 +48,7 @@ _DENSE_TESTS = (
 class GLUTest(parameterized.TestCase):
 
     @parameterized.parameters(*_DENSE_TESTS)
-    def testGLU_forward_grouped_mlp(self, bs, sl, hs):
+    def testGLU_ForwardGroupedMLP(self, bs, sl, hs):
 
         x = torch.randn(sl, bs, hs).to(torch.bfloat16).cuda()
 
@@ -67,7 +67,7 @@ class GLUTest(parameterized.TestCase):
         self.assertTrue(testing.allclose(out, expected_out))
 
     @parameterized.parameters(*_DENSE_TESTS)
-    def testGLU_forward_sparse(self, bs, sl, hs):
+    def testGLU_ForwardSparseMLP(self, bs, sl, hs):
         x = torch.randn(sl, bs, hs).to(torch.bfloat16).cuda()
 
         _, glu, dmoe_glu = test_modules(

--- a/megablocks/layers/glu_test.py
+++ b/megablocks/layers/glu_test.py
@@ -1,0 +1,74 @@
+import unittest
+from functools import partial
+
+from absl.testing import parameterized
+from megablocks.layers.arguments import Arguments
+from megablocks.layers import dmoe
+from megablocks.layers import testing
+import torch
+
+
+def test_modules(
+        hidden_size,
+        ffn_hidden_size,
+        moe_num_experts=1,
+        moe_capacity_factor=1,
+        moe_top_k=1,
+        use_grouped_gemm=False):
+    init_method = partial(torch.nn.init.normal_, mean=0.0, std=0.1)
+    args = Arguments(
+        hidden_size=hidden_size,
+        ffn_hidden_size=ffn_hidden_size,
+        moe_num_experts=moe_num_experts,
+        moe_capacity_factor=moe_capacity_factor,
+        moe_top_k=moe_top_k,
+        init_method=init_method,
+        memory_optimized_mlp=False,
+        mlp_type='glu',
+        use_grouped_gemm=use_grouped_gemm,
+        fp16=False,
+        bf16=True)
+
+    glu = testing.GLU(args)
+    dmoe_glu = dmoe.dMoE(args)
+
+    glu.cuda(torch.cuda.current_device()).to(torch.bfloat16)
+    dmoe_glu.cuda(torch.cuda.current_device()).to(torch.bfloat16)
+
+    with torch.no_grad():
+        if moe_num_experts == 1:
+            glu.w1.copy_(dmoe_glu.experts.mlp.w1.T)
+            glu.v1.copy_(dmoe_glu.experts.mlp.v1.T)
+            glu.w2.copy_(dmoe_glu.experts.mlp.w2)
+    return args, glu, dmoe_glu
+
+_DENSE_TESTS = (
+    (16, 1024, 512),
+    (8, 2048, 512),
+)
+
+_DENSE_TESTS_GROUPED = tuple([
+    p + (True, ) for p in _DENSE_TESTS
+])
+_ALL_DENSE_TESTS = (_DENSE_TESTS + _DENSE_TESTS_GROUPED)
+
+
+class GLUTest(parameterized.TestCase):
+
+    @parameterized.parameters(*_ALL_DENSE_TESTS)
+    def testdMoE_ForwardVersusBaseline(self, bs, sl, hs, use_grouped_gemm=False):
+        x = torch.randn(sl, bs, hs).to(torch.bfloat16).cuda()
+
+        _, glu, dmoe_glu = test_modules(
+            hidden_size=hs,
+            ffn_hidden_size=hs * 2,
+            use_grouped_gemm=use_grouped_gemm)
+
+        expected_out = glu(x)
+        out, _ = dmoe_glu(x)
+        self.assertSequenceEqual(out.shape, x.shape)
+        self.assertSequenceEqual(expected_out.shape, x.shape)
+        self.assertTrue(testing.allclose(out, expected_out))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/megablocks/layers/glu_test.py
+++ b/megablocks/layers/glu_test.py
@@ -76,12 +76,9 @@ class GLUTest(parameterized.TestCase):
             grouped_mlp=False)
 
         expected_out = glu(x)
-
         with torch.no_grad():
             topo = stk.random.mask(bs * sl, hs * 2, 0, blocking=128).cuda()
-
         out = dmoe_glu(x.view(bs * sl, hs), topo)
-
         out = out.view(sl, bs, hs)
 
         self.assertSequenceEqual(out.shape, x.shape)

--- a/megablocks/layers/glu_test.py
+++ b/megablocks/layers/glu_test.py
@@ -3,43 +3,118 @@ from functools import partial
 
 from absl.testing import parameterized
 from megablocks.layers.arguments import Arguments
-from megablocks.layers import dmoe
+from megablocks.layers.glu import SparseGLU, GroupedGLU
 from megablocks.layers import testing
+
+from megablocks import ops
 import torch
+import stk
+import numpy as np
+
+def _sparse_transpose(size, row_indices, column_indices, offsets, blocking, transpose_sort_end_bit):
+    block_columns = size[1] // blocking
+
+    # Sort row indices by column indices to get the transposed matrix's
+    # column indices.
+    #
+    # NOTE: Our sort operation uses the same width indices as the input values.
+    # To avoid overflow when we have large activation matrices we cast to
+    # 32-bit before sorting.
+    _, gather_indices = ops.sort(
+        column_indices.int(), transpose_sort_end_bit)
+
+    # There are a constant number of blocks in every row of the sparse matrix.
+    # A blocks offset is:
+    #
+    # row_index * blocks_per_row + column_index % blocks_per_row
+    #
+    # Once we have the block offsets ordered for transposition we can divide
+    # by blocks_per_row to get the transposed column indices.
+    column_indices_t = row_indices.gather(0, gather_indices.long())
+    block_offsets_t = gather_indices.int()
+
+    zero = torch.zeros((1,), dtype=torch.int32, device=row_indices.device)
+    nnz_per_column = ops.histogram(column_indices, block_columns)
+    nnz_per_column = ops.inclusive_cumsum(nnz_per_column, 0)
+    offsets_t = torch.cat([zero, nnz_per_column])
+    return column_indices_t, offsets_t, block_offsets_t
+
+def _setup_topology(bs, sl, ffn_hidden_size, blocking=128, dtype=torch.bfloat16):
+    padded_tokens = bs * sl
+    padded_bins = torch.tensor([bs * sl]).type(torch.int32).cuda()
+    block_rows = padded_tokens // blocking
+    blocks_per_row = ffn_hidden_size // blocking
+
+    # equivaelent to blocks_per_row in the 1 expert case
+    max_column_index = blocks_per_row
+
+    transpose_sort_end_bit = max(int(np.ceil(np.log2(max_column_index))), 1)
+
+    offsets = torch.arange(
+        0,
+        block_rows * blocks_per_row + 1,
+        blocks_per_row,
+        dtype=torch.int32,
+        device='cuda')
+
+    column_indices = ops.topology(
+            padded_bins, 
+            blocking,
+            block_rows,
+            blocks_per_row
+        )
+    data = torch.empty(
+        column_indices.numel(),
+        blocking,
+        blocking,
+        dtype=dtype,
+        device='cuda') 
+
+    padded_tokens = bs * sl
+
+    shape = (
+        padded_tokens,
+        ffn_hidden_size
+    )
+
+    row_indices = stk.ops.row_indices(
+        shape, data, offsets, column_indices)
+    
+    column_indices_t, offsets_t, block_offsets_t = _sparse_transpose(
+        shape, row_indices, column_indices, offsets, blocking, transpose_sort_end_bit)
+    
+    return stk.Matrix(shape, data, row_indices, column_indices, offsets,
+                        column_indices_t, offsets_t, block_offsets_t)
 
 
 def test_modules(
         hidden_size,
         ffn_hidden_size,
-        moe_num_experts=1,
-        moe_capacity_factor=1,
-        moe_top_k=1,
-        use_grouped_gemm=False):
+        grouped_mlp=False):
     init_method = partial(torch.nn.init.normal_, mean=0.0, std=0.1)
     args = Arguments(
         hidden_size=hidden_size,
         ffn_hidden_size=ffn_hidden_size,
-        moe_num_experts=moe_num_experts,
-        moe_capacity_factor=moe_capacity_factor,
-        moe_top_k=moe_top_k,
+        moe_num_experts=1,
+        moe_top_k=1,
         init_method=init_method,
         memory_optimized_mlp=False,
         mlp_type='glu',
-        use_grouped_gemm=use_grouped_gemm,
+        grouped_mlp=grouped_mlp,
         fp16=False,
         bf16=True)
 
     glu = testing.GLU(args)
-    dmoe_glu = dmoe.dMoE(args)
+    dmoe_glu = GroupedGLU(args) if grouped_mlp else SparseGLU(args)
 
-    glu.cuda(torch.cuda.current_device()).to(torch.bfloat16)
     dmoe_glu.cuda(torch.cuda.current_device()).to(torch.bfloat16)
+    glu.cuda(torch.cuda.current_device()).to(torch.bfloat16)
 
     with torch.no_grad():
-        if moe_num_experts == 1:
-            glu.w1.copy_(dmoe_glu.experts.mlp.w1.T)
-            glu.v1.copy_(dmoe_glu.experts.mlp.v1.T)
-            glu.w2.copy_(dmoe_glu.experts.mlp.w2)
+        glu.w1.copy_(dmoe_glu.w1.T)
+        glu.v1.copy_(dmoe_glu.v1.T)
+        glu.w2.copy_(dmoe_glu.w2)
+
     return args, glu, dmoe_glu
 
 _DENSE_TESTS = (
@@ -47,25 +122,44 @@ _DENSE_TESTS = (
     (8, 2048, 512),
 )
 
-_DENSE_TESTS_GROUPED = tuple([
-    p + (True, ) for p in _DENSE_TESTS
-])
-_ALL_DENSE_TESTS = (_DENSE_TESTS + _DENSE_TESTS_GROUPED)
-
-
 class GLUTest(parameterized.TestCase):
 
-    @parameterized.parameters(*_ALL_DENSE_TESTS)
-    def testdMoE_ForwardVersusBaseline(self, bs, sl, hs, use_grouped_gemm=False):
+    @parameterized.parameters(*_DENSE_TESTS)
+    def testGLU_forward_grouped_mlp(self, bs, sl, hs):
+
         x = torch.randn(sl, bs, hs).to(torch.bfloat16).cuda()
 
         _, glu, dmoe_glu = test_modules(
             hidden_size=hs,
             ffn_hidden_size=hs * 2,
-            use_grouped_gemm=use_grouped_gemm)
+            grouped_mlp=True)
 
         expected_out = glu(x)
-        out, _ = dmoe_glu(x)
+        tokens_per_expert = torch.tensor([bs * sl]).cuda()
+        out = dmoe_glu(x.view(bs * sl, hs), tokens_per_expert)
+        out = out.view(sl, bs, hs)
+
+        self.assertSequenceEqual(out.shape, x.shape)
+        self.assertSequenceEqual(expected_out.shape, x.shape)
+        self.assertTrue(testing.allclose(out, expected_out))
+
+    @parameterized.parameters(*_DENSE_TESTS)
+    def testGLU_forward_sparse(self, bs, sl, hs):
+        x = torch.randn(sl, bs, hs).to(torch.bfloat16).cuda()
+
+        _, glu, dmoe_glu = test_modules(
+            hidden_size=hs,
+            ffn_hidden_size=hs * 2,
+            grouped_mlp=False)
+
+        expected_out = glu(x)
+
+        with torch.no_grad():
+            topo = _setup_topology(bs, sl, hs * 2)
+        out = dmoe_glu(x.view(bs * sl, hs), topo)
+
+        out = out.view(sl, bs, hs)
+
         self.assertSequenceEqual(out.shape, x.shape)
         self.assertSequenceEqual(expected_out.shape, x.shape)
         self.assertTrue(testing.allclose(out, expected_out))

--- a/megablocks/layers/glu_test.py
+++ b/megablocks/layers/glu_test.py
@@ -68,7 +68,7 @@ def _setup_topology(bs, sl, ffn_hidden_size, blocking=128, dtype=torch.bfloat16)
         blocking,
         blocking,
         dtype=dtype,
-        device='cuda') 
+        device='meta') 
 
     padded_tokens = bs * sl
 

--- a/megablocks/layers/mlp_registry.py
+++ b/megablocks/layers/mlp_registry.py
@@ -1,0 +1,28 @@
+from typing import Union
+from megablocks.layers import mlp
+from megablocks.layers import glu
+from megablocks.layers.arguments import Arguments
+
+MlpType = Union[mlp.SparseMLP, glu.SparseGLU]
+
+class MlpRegistry:
+    """
+    Abstraction for creating different underlying MLPs.
+    """
+    REGISTRY = {
+        'mlp': {'grouped': mlp.GroupedMLP, 'sparse' : mlp.SparseMLP},
+        'glu': {'grouped': glu.GroupedGLU, 'sparse': glu.SparseGLU},
+    }
+
+    @staticmethod
+    def get(args: Arguments) -> MlpType:
+
+        if args.mlp_type not in MlpRegistry.REGISTRY: 
+            raise ValueError(f'Unsupported mlp type: {args.mlp_type}')
+
+        mlp_impl = 'grouped' if args.use_grouped_gemm else 'sparse'
+
+        if mlp_impl not in MlpRegistry.REGISTRY[args.mlp_type]:
+            raise ValueError(f'{args.mlp_type} does not support {mlp_impl} backend.')
+
+        return MlpRegistry.REGISTRY[args.mlp_type][mlp_impl](args)

--- a/megablocks/layers/testing.py
+++ b/megablocks/layers/testing.py
@@ -30,3 +30,17 @@ class FFN(torch.nn.Module):
     def forward(self, x):
         return torch.matmul(F.gelu(
             torch.matmul(x, self.w1), approximate="tanh"), self.w2)
+
+class GLU(FFN):
+
+    def __init__(self, args : Arguments):
+        super().__init__(args)
+        self.v1 = torch.nn.Parameter(torch.empty(
+            args.hidden_size,
+            args.ffn_hidden_size,
+            device=args.device,
+            dtype=torch.float16 if args.fp16 else torch.float32))
+
+    def forward(self, x):
+        x1 = F.gelu(torch.matmul(x, self.w1), approximate="tanh") * torch.matmul(x, self.v1)
+        return torch.matmul(x1, self.w2)


### PR DESCRIPTION
This change adds GLU blocks to megablocks (replacing vanilla MLPs), and does some refactoring around the mlp types, including an `MLP_TYPE_REGISTRY`. 
Note, this is unoptimized at the moment:
- no support for the memory optimized mlp version yet
- w1 & v1 are not fused into one op that is split