### PR TITLE
Have megablocks rely on torch default precision

### DIFF
--- a/megablocks/layers/common.py
+++ b/megablocks/layers/common.py
@@ -2,12 +2,11 @@ from megablocks.layers.arguments import Arguments
 import torch
 
 def dtype(args : Arguments):
-    dtype = torch.float32
     if args.fp16:
-        dtype = torch.float16
+        return torch.float16
     elif args.bf16:
-        dtype = torch.bfloat16
-    return dtype
+        return torch.bfloat16
+    return None
 
 
 def cast_if_autocast_enabled(tensor):


### PR DESCRIPTION
Have megablocks rely on torch default precision when creating new tensors. Many external libraries, e.g. HF, rely on this