### PR TITLE
Removing an extra size call

### DIFF
--- a/megablocks/layers/dmoe.py
+++ b/megablocks/layers/dmoe.py
@@ -316,7 +316,6 @@ class dMoE(torch.nn.Module):
         # NOTE: If we're going to cast the activations to lower precision
         # do it before we permute the tokens to save bandwidth.
         x = common.cast_if_autocast_enabled(x)
-        sl, bs, hs = x.size()
 
         # Compute the expert scores and assignments.
         scores, expert_weights, top_experts = self.router(x)


### PR DESCRIPTION
There's an extra size call that is unused but makes assumptions about a tensor's dimensions:

https://github.com/stanford-futuredata/megablocks/commit/6e09bc50fbfde38d75d7b741722cd99149014e0e