### PR TITLE
Add expert dropout

### DIFF
--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -27,6 +27,7 @@ class Arguments:
     moe_loss_weight : float = 0.1
     moe_jitter_eps : Optional[float] = None
     moe_lbl_in_fp32 : bool = False
+    moe_expert_dropout_rate : float = 0.0
 
     # Parallelism arguments.
     moe_expert_model_parallelism : bool = False


### PR DESCRIPTION
From the Switch paper, "We thus propose a simple way to alleviate [MoE overfitting] during fine tuning: increase the dropout inside the experts, which we name as expert dropout. During fine-tuning we simply increase the dropout rate by a significant amount only at the interim feed-forward computation at each expert layer."