### PR TITLE
Skip updating load balancing loss on eval

### DIFF
--- a/megablocks/layers/moe.py
+++ b/megablocks/layers/moe.py
@@ -424,7 +424,8 @@ class ParallelMLP(torch.nn.Module):
         # Compute the experts.
         x, tokens_per_expert = self.forward_fn(
             x, expert_weights, top_experts)
-        save_load_balancing_loss((tokens_per_expert, scores))
+        if self.training:
+            save_load_balancing_loss((tokens_per_expert, scores))
         x = x.view(in_shape)
         if self.bias is not None:
             if self.args.return_bias:


### PR DESCRIPTION
Currently the model updates the load balancing loss during every forward pass.

So if we have a pipeline like that does validation every X batches, it's going to lead to an assert error like `Expected 6 token_per_experts but found 54`

This PR fixes it so that it only updates the load balancing loss during forward passes of model.train() and not model.eval()