### PR TITLE
Change router weight norm from in-place

### DIFF
--- a/megablocks/layers/router.py
+++ b/megablocks/layers/router.py
@@ -56,7 +56,7 @@ class LearnedRouter(torch.nn.Module):
         scores = self.layer(x.view(-1, x.shape[-1])).softmax(dim=-1)
         expert_weights, expert_indices = self._top_k(scores)
         if self.args.moe_normalize_expert_weights:
-            expert_weights /= torch.norm(
+            expert_weights = expert_weights / torch.norm(
                 expert_weights, p=self.args.moe_normalize_expert_weights,dim=-1, keepdim=True)
 
         expert_indices = (


### PR DESCRIPTION
I was seeing:

```
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor [8192, 2]], which is output 0 of DivBackward0, is at version 1; expected version 0 instead. Hint: enable anomaly detection to find the operation that failed to compute its gradient, with torch.autograd.set_detect_anomaly(True).
```

This change addresses that issue.