### PR TITLE
Add dmlp registry args

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ NOTE: This assumes you have `numpy` and `torch` installed.
 
 Installing `megablocks[quant]` enables configurable quantization of saved activations in the dMoE layer to save memory during training. The degree of quantization is controlled via the `quantize_inputs_num_bits`, `quantize_rematerialize_num_bits` and `quantize_scatter_num_bits` [arguments](https://github.com/stanford-futuredata/megablocks/blob/main/megablocks/layers/arguments.py).
 
-Installing `megablocks[gg]` enables dMoE computation with grouped GEMM. This feature is enabled by setting the `grouped_mlp` argument to the dMoE layer. This is currently our recommended path for Hopper-generation GPUs.
+Installing `megablocks[gg]` enables dMoE computation with grouped GEMM. This feature is enabled by setting the `mlp_impl` argument to `grouped`. This is currently our recommended path for Hopper-generation GPUs.
 
 MegaBlocks can be installed with all dependencies via the `megablocks[all]` package.
 

--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -44,7 +44,7 @@ class Arguments:
     # Compute arguments.
     memory_optimized_mlp : bool = False
     mlp_type : str = 'mlp'
-    grouped_mlp : bool = False
+    mlp_impl : str = 'grouped'
     quantize_inputs_num_bits: int = -1  # -1 = no quantization
     quantize_rematerialize_num_bits: int = -1
     quantize_scatter_num_bits: int = -1
@@ -71,7 +71,7 @@ class Arguments:
             if nbits != -1:
                 turbo.assert_turbo_is_available()
 
-        if self.__getattribute__('grouped_mlp'):
+        if self.__getattribute__('mlp_impl') == 'grouped':
             grouped_gemm.assert_grouped_gemm_is_available()
 
 

--- a/megablocks/layers/dmlp_registry.py
+++ b/megablocks/layers/dmlp_registry.py
@@ -27,9 +27,7 @@ def get(args: Arguments) -> MlpType:
     if args.mlp_type not in _REGISTRY: 
         raise ValueError(f'Unsupported mlp type: {args.mlp_type}')
 
-    mlp_impl = 'grouped' if args.grouped_mlp else 'sparse'
+    if args.mlp_impl not in _REGISTRY[args.mlp_type]:
+        raise ValueError(f'{args.mlp_type} does not support {args.mlp_impl} backend.')
 
-    if mlp_impl not in _REGISTRY[args.mlp_type]:
-        raise ValueError(f'{args.mlp_type} does not support {mlp_impl} backend.')
-
-    return _REGISTRY[args.mlp_type][mlp_impl](args)
+    return _REGISTRY[args.mlp_type][args.mlp_impl](args)

--- a/megablocks/layers/dmoe.py
+++ b/megablocks/layers/dmoe.py
@@ -264,11 +264,13 @@ class ParallelDroplessMLP(moe.ParallelMLP):
             self.args.quantize_scatter_num_bits)
 
     def forward_once(self, x, expert_weights, top_experts):
-        if self.args.grouped_mlp:
+        if self.args.mlp_impl == 'sparse':
+            return self.sparse_forward_once(
+                x, expert_weights, top_experts)
+        else:
             return self.grouped_forward_once(
                 x, expert_weights, top_experts)
-        return self.sparse_forward_once(
-            x, expert_weights, top_experts)
+
 
     def permute_and_compute(
             self,
@@ -280,7 +282,17 @@ class ParallelDroplessMLP(moe.ParallelMLP):
             bins,
             expert_capactiy,
             top_k):
-        if self.args.grouped_mlp:
+        if self.args.mlp_impl == 'sparse':
+            return self.sparse_permute_and_compute(
+                x,
+                tokens_per_expert,
+                indices,
+                bin_ids,
+                expert_weights,
+                bins,
+                expert_capactiy,
+                top_k)
+        else:
             return self.grouped_permute_and_compute(
                 x,
                 tokens_per_expert,
@@ -290,15 +302,6 @@ class ParallelDroplessMLP(moe.ParallelMLP):
                 bins,
                 expert_capactiy,
                 top_k)
-        return self.sparse_permute_and_compute(
-            x,
-            tokens_per_expert,
-            indices,
-            bin_ids,
-            expert_weights,
-            bins,
-            expert_capactiy,
-            top_k)
 
 
 class dMoE(torch.nn.Module):

--- a/megablocks/layers/dmoe_test.py
+++ b/megablocks/layers/dmoe_test.py
@@ -19,7 +19,7 @@ def test_modules(
         moe_top_k=1,
         num_input_bits=-1,
         num_remat_bits=-1,
-        grouped_mlp=False):
+        mlp_impl='sparse'):
     init_method = partial(torch.nn.init.normal_, mean=0.0, std=0.1)
     args = Arguments(
         hidden_size=hidden_size,
@@ -32,7 +32,7 @@ def test_modules(
         quantize_inputs_num_bits=num_input_bits,
         quantize_rematerialize_num_bits=num_remat_bits,
         mlp_type='mlp',
-        grouped_mlp=grouped_mlp,
+        mlp_impl=mlp_impl,
         fp16=False,
         bf16=True)
 
@@ -74,7 +74,7 @@ _FORWARD_TESTS_NO_QUANTIZE = (
 )
 
 _FORWARD_TESTS_GROUPED_MLP = tuple([
-    p + (-1, -1, True) for p in _FORWARD_TESTS_NO_QUANTIZE
+    p + (-1, -1, 'grouped') for p in _FORWARD_TESTS_NO_QUANTIZE
 ]) if gg.grouped_gemm_is_available() else ()
 
 # quantization tests; assorted small sizes, systematic bitwidths
@@ -123,7 +123,7 @@ class dMoETest(parameterized.TestCase):
     @parameterized.parameters(*_FORWARD_TESTS)
     def testdMoE_Forward(self, bs, sl, hs, num_experts, top_k,
                          num_input_bits=-1, num_remat_bits=-1,
-                         grouped_mlp=False):
+                         mlp_impl='sparse'):
         x = torch.randn(sl, bs, hs).to(torch.bfloat16).cuda()
 
         _, _, _, layer = test_modules(
@@ -133,7 +133,7 @@ class dMoETest(parameterized.TestCase):
             moe_top_k=top_k,
             num_input_bits=num_input_bits,
             num_remat_bits=num_remat_bits,
-            grouped_mlp=grouped_mlp)
+            mlp_impl=mlp_impl)
 
         out, _ = layer(x)
         self.assertSequenceEqual(out.shape, x.shape)
@@ -142,7 +142,7 @@ class dMoETest(parameterized.TestCase):
     def testdMoE_ForwardBackward(
             self, bs, sl, hs, num_experts, top_k,
             num_input_bits=-1, num_remat_bits=-1,
-            grouped_mlp=False):
+            mlp_impl='sparse'):
         x = torch.randn(sl, bs, hs).to(torch.bfloat16).cuda()
         x.requires_grad_(True)
 
@@ -153,7 +153,7 @@ class dMoETest(parameterized.TestCase):
             moe_top_k=top_k,
             num_input_bits=num_input_bits,
             num_remat_bits=num_remat_bits,
-            grouped_mlp=grouped_mlp)
+            mlp_impl=mlp_impl)
 
         out, _ = layer(x)
         self.assertSequenceEqual(out.shape, x.shape)
@@ -184,7 +184,7 @@ class dMoETest(parameterized.TestCase):
     def testdMoE_ForwardVersusMoE(
             self, bs, sl, hs, num_experts, top_k,
             num_input_bits=-1, num_remat_bits=-1,
-            grouped_mlp=False):
+            mlp_impl='sparse'):
         torch.manual_seed(42)
 
         x = torch.randn(sl, bs, hs).to(torch.bfloat16).cuda()
@@ -194,7 +194,7 @@ class dMoETest(parameterized.TestCase):
             ffn_hidden_size=hs,
             moe_num_experts=num_experts,
             moe_capacity_factor=0,
-            grouped_mlp=grouped_mlp)
+            mlp_impl=mlp_impl)
 
         expected_out, _= moe_mlp(x)
         out, _ = dmoe_mlp(x)

--- a/megablocks/layers/moe.py
+++ b/megablocks/layers/moe.py
@@ -375,7 +375,7 @@ class ParallelMLP(torch.nn.Module):
 
         # Locally permute the tokens and perform the expert computation.
         # Block to make sure that the cross-device permutation is complete.
-        if isinstance(self.mlp, mlp.GroupedMLP):
+        if self.args.mlp_impl == 'grouped':
             # GroupedMLP requires counts on CPU. We can use the tensor already
             # moved to CPU for the prior all_to_all, which avoids an extra
             # device synchronization.


### PR DESCRIPTION
# Description
Add mlp_impl flag so that all mlp implementations will be specified with `grouped` or `sparse`

# Tests
- dmoe_test.py ✅ 
- moe_test.py ✅ 
- glu_test.py ✅ 

End to end run:
- Ran a short training run with grouped to verify it worked