### PR TITLE
Fix `moe_normalize_expert_weights` when `top_k=1`

### DIFF
--- a/megablocks/layers/router.py
+++ b/megablocks/layers/router.py
@@ -43,21 +43,16 @@ class LearnedRouter(torch.nn.Module):
         noise = torch.rand(x.size(), dtype=x.dtype, device=x.device)
         return low + noise * (high - low)
 
-    def _top_k(self, scores):
-        if self.args.moe_top_k == 1:
-            return scores.max(dim=-1)
-        return torch.topk(scores, self.args.moe_top_k, dim=-1)
-
-
     def forward(self, x):
         if self.training and self.args.moe_jitter_eps is not None:
             x = x * self.jitter(x)
 
         scores = self.layer(x.view(-1, x.shape[-1])).softmax(dim=-1)
-        expert_weights, expert_indices = self._top_k(scores)
+        expert_weights, expert_indices = torch.topk(scores, self.args.moe_top_k, dim=-1)
         if self.args.moe_normalize_expert_weights:
             expert_weights = expert_weights / torch.norm(
                 expert_weights, p=self.args.moe_normalize_expert_weights,dim=-1, keepdim=True)
+        if self.args.moe_top_k == 1: expert_indices = expert_indices.squeeze(-1)
 
         expert_indices = (
             _uniform_expert_assignment(expert_indices, self.args.moe_num_experts)

--- a/megablocks/layers/router.py
+++ b/megablocks/layers/router.py
@@ -57,7 +57,6 @@ class LearnedRouter(torch.nn.Module):
         if self.args.moe_normalize_expert_weights:
             expert_weights = expert_weights / torch.norm(
                 expert_weights, p=self.args.moe_normalize_expert_weights,dim=-1, keepdim=True)
-        if self.args.moe_top_k == 1: expert_indices = expert_indices.squeeze(-1)
 
         expert_indices = (
             _uniform_expert_assignment(expert_indices, self.args.moe_num_experts)


### PR DESCRIPTION
The router.py function,
```python
    def _top_k(self, scores):
        if self.args.moe_top_k == 1:
            return scores.max(dim=-1) # <-- causes weight shape to become [S]
        return torch.topk(scores, self.args.moe_top_k, dim=-1) # <-- shape is normally [S,K]
```
caused expert weight norm to be calculated wrong:
```python
        expert_weights, expert_indices = self._top_k(scores)
        if self.args.moe_normalize_expert_weights:
            # this function expects dim=-1 to only contain a single token's weights
            expert_weights = expert_weights / torch.norm(
                expert_weights, p=self.args.moe_normalize_expert_weights,dim=-1, keepdim=True)
```
After this PR, top-1 models with moe_normalize_expert_weights=1 should always have the final weights become 1 (where previously they would be divided weirdly)